### PR TITLE
TileBase Module

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
         "BigInt": true
     },
     "parserOptions": {
+        "sourceType": "module",
         "ecmaVersion": 13
     },
     "plugins": [ "node" ],
@@ -41,8 +42,6 @@
         "keyword-spacing": [ "error", { "before": true, "after": true } ],
         "template-curly-spacing": [ "error", "never" ],
         "semi-spacing": "error",
-        "strict": "error",
-        "node/no-unsupported-features": [ "error", { "version": 8 } ],
         "node/no-missing-require": "error",
         "valid-jsdoc": ["error", {
             "requireParamDescription": false,

--- a/cli.js
+++ b/cli.js
@@ -1,17 +1,17 @@
 #! /usr/bin/env node
 
-'use strict';
+import { URL } from 'url';
+import fs from 'fs';
+import TileBase from './tilebase.js';
+import minimist from 'minimist';
 
-const pkg = require('./package.json');
-const path = require('path');
-const TileBase = require('.');
-const argv = require('minimist')(process.argv, {
+const argv = minimist(process.argv, {
     boolean: ['help', 'version']
 });
 
-if (argv.version) return version();
-if (argv.help || !argv._[2]) return help();
-if (argv._[2] === 'convert') return convert();
+if (argv.version) version();
+else if (argv.help || !argv._[2]) help();
+else if (argv._[2] === 'convert') convert();
 
 function help() {
     if (!argv._[2]) {
@@ -40,6 +40,7 @@ function help() {
 }
 
 function version() {
+    const pkg = JSON.parse(fs.readFileSync(new URL('package.json', import.meta.url).pathname));
     console.log(`TileBase@${pkg.version}`);
 }
 
@@ -51,8 +52,8 @@ async function convert() {
 
     try {
         const tb = await TileBase.to_tb(
-            path.resolve(__dirname, argv._[3]),
-            path.resolve(__dirname, argv._[4])
+            new URL(argv._[3], import.meta.url).pathname,
+            new URL(argv._[4], import.meta.url).pathname
         );
 
         await tb.open();

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,8 +1,12 @@
 'use strict';
 
-const fs = require('fs');
-const Ajv = require('ajv');
-const schema = require('./schema.json');
+import fs from 'fs';
+import Ajv from 'ajv';
+import { dirname } from 'path';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const schema = fs.readFileSync(path.resolve(dirname(fileURLToPath(import.meta.url)), './schema.json'));
 
 /**
  * @class
@@ -105,4 +109,4 @@ class Config {
     }
 }
 
-module.exports = Config;
+export default Config;

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 import fs from 'fs';
 import Ajv from 'ajv';
@@ -6,7 +6,7 @@ import { dirname } from 'path';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-const schema = fs.readFileSync(path.resolve(dirname(fileURLToPath(import.meta.url)), './schema.json'));
+const schema = JSON.parse(fs.readFileSync(path.resolve(dirname(fileURLToPath(import.meta.url)), './schema.json')));
 
 /**
  * @class

--- a/lib/error.js
+++ b/lib/error.js
@@ -14,4 +14,4 @@ class TBError extends Error {
     }
 }
 
-module.exports = TBError;
+export default TBError;

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,4 +1,4 @@
-'use strict';
+
 
 /**
  * @class

--- a/lib/interfaces.js
+++ b/lib/interfaces.js
@@ -1,7 +1,11 @@
 'use strict';
-module.exports = {
-    'file:': require('./interfaces/file'),
-    's3:': require('./interfaces/s3'),
-    'http:': require('./interfaces/http'),
-    'https:': require('./interfaces/http')
+import file from './interfaces/file.js';
+import s3 from './interfaces/s3.js';
+import http from './interfaces/http.js';
+
+export default {
+    'file:': file,
+    's3:': s3,
+    'http:': http,
+    'https:': http
 };

--- a/lib/interfaces.js
+++ b/lib/interfaces.js
@@ -1,4 +1,4 @@
-'use strict';
+
 import file from './interfaces/file.js';
 import s3 from './interfaces/s3.js';
 import http from './interfaces/http.js';

--- a/lib/interfaces/file.js
+++ b/lib/interfaces/file.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fs = require('fs/promises');
+import fs from 'fs/promises';
 
 /**
  * @class
@@ -44,4 +44,4 @@ class TileBaseFile {
     }
 }
 
-module.exports = TileBaseFile;
+export default TileBaseFile;

--- a/lib/interfaces/http.js
+++ b/lib/interfaces/http.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const fetch = require('node-fetch');
+import fetch from 'node-fetch';
 
 /**
  * @class
@@ -44,4 +44,4 @@ class TileBaseHTTP {
     }
 }
 
-module.exports = TileBaseHTTP;
+export default TileBaseHTTP;

--- a/lib/interfaces/s3.js
+++ b/lib/interfaces/s3.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const AWS = require('aws-sdk');
+import AWS from 'aws-sdk';
 const s3 = new AWS.S3();
 
 /**
@@ -45,4 +45,4 @@ class TileBaseS3 {
     }
 }
 
-module.exports = TileBaseS3;
+export default TileBaseS3;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "name": "tilebase",
+    "type": "module",
     "version": "1.6.1",
     "description": "Range based Single File MBTiles like Store",
     "main": "tilebase.js",

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const path = require('path');
-const test = require('tape');
-const TileBase = require('../');
-const TBError = require('../lib/error');
+import path from 'path';
+import test from 'tape';
+import TileBase from '../tilebase.js';
+import TBError from '../lib/error.js';
 
 test('Errors', async (t) => {
     try {

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,13 +1,10 @@
-'use strict';
-
-import path from 'path';
 import test from 'tape';
 import TileBase from '../tilebase.js';
 import TBError from '../lib/error.js';
 
 test('Errors', async (t) => {
     try {
-        const tb = new TileBase('file://' + path.resolve(__dirname, './fixtures', 'min.tb'));
+        const tb = new TileBase('file://' + new URL('./fixtures/min.tb', import.meta.url).pathname);
 
         try {
             await tb.tile(1, 1, 1);

--- a/test/file.test.js
+++ b/test/file.test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const test = require('tape');
-const path = require('path');
-const TileBase = require('../tilebase.js');
-const { VectorTile } = require('@mapbox/vector-tile');
-const Protobuf = require('pbf');
+import test from 'tape';
+import path from 'path';
+import TileBase from '../tilebase.js';
+import { VectorTile } from '@mapbox/vector-tile';
+import Protobuf from 'pbf';
 
 test('TileBase(file://) prep', async (t) => {
     try {

--- a/test/file.test.js
+++ b/test/file.test.js
@@ -1,14 +1,11 @@
-'use strict';
-
 import test from 'tape';
-import path from 'path';
 import TileBase from '../tilebase.js';
 import { VectorTile } from '@mapbox/vector-tile';
 import Protobuf from 'pbf';
 
 test('TileBase(file://) prep', async (t) => {
     try {
-        await TileBase.to_tb(path.resolve(__dirname, './fixtures/single.mbtiles'), '/tmp/test.tb');
+        await TileBase.to_tb(new URL('./fixtures/single.mbtiles', import.meta.url).pathname, '/tmp/test.tb');
     } catch (err) {
         t.error(err, 'no errors');
     }

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const test = require('tape');
-const TileBase = require('../tilebase.js');
-const { VectorTile } = require('@mapbox/vector-tile');
-const Protobuf = require('pbf');
+import test from 'tape';
+import TileBase from '../tilebase.js';
+import { VectorTile } from '@mapbox/vector-tile';
+import Protobuf from 'pbf';
 
 test('TileBase(http://)', async (t) => {
     try {

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import test from 'tape';
 import TileBase from '../tilebase.js';
 import { VectorTile } from '@mapbox/vector-tile';

--- a/test/https.test.js
+++ b/test/https.test.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const test = require('tape');
-const TileBase = require('../tilebase.js');
-const { VectorTile } = require('@mapbox/vector-tile');
-const Protobuf = require('pbf');
+import test from 'tape';
+import TileBase from '../tilebase.js';
+import { VectorTile } from '@mapbox/vector-tile';
+import Protobuf from 'pbf';
 
 test('TileBase(https://)', async (t) => {
     try {

--- a/test/https.test.js
+++ b/test/https.test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import test from 'tape';
 import TileBase from '../tilebase.js';
 import { VectorTile } from '@mapbox/vector-tile';

--- a/test/index_count.test.js
+++ b/test/index_count.test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import test from 'tape';
 import Config from '../lib/config.js';
 

--- a/test/index_count.test.js
+++ b/test/index_count.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const test = require('tape');
-const Config = require('../lib/config');
+import test from 'tape';
+import Config from '../lib/config.js';
 
 test('config#index_count - simply', (t) => {
     const cnf = new Config({});

--- a/test/min.test.js
+++ b/test/min.test.js
@@ -1,12 +1,9 @@
-'use strict';
-
-import path = from 'path';
 import test from 'tape';
 import TileBase from '../tilebase.js';
 
 test('Min', async (t) => {
     try {
-        const tb = new TileBase('file://' + path.resolve(__dirname, './fixtures', 'min.tb'));
+        const tb = new TileBase('file://' + new URL('./fixtures/min.tb', import.meta.url).pathname);
         await tb.open();
 
         t.deepEquals(tb.config.config, {

--- a/test/min.test.js
+++ b/test/min.test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const path = require('path');
-const test = require('tape');
-const TileBase = require('../');
+import path = from 'path';
+import test from 'tape';
+import TileBase from '../tilebase.js';
 
 test('Min', async (t) => {
     try {

--- a/test/s3.test.js
+++ b/test/s3.test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import test from 'tape';
 import TileBase from '../tilebase.js';
 import { VectorTile } from '@mapbox/vector-tile';

--- a/test/s3.test.js
+++ b/test/s3.test.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const test = require('tape');
-const TileBase = require('../tilebase.js');
-const { VectorTile } = require('@mapbox/vector-tile');
-const Protobuf = require('pbf');
+import test from 'tape';
+import TileBase from '../tilebase.js';
+import { VectorTile } from '@mapbox/vector-tile';
+import Protobuf from 'pbf';
 
 test('TileBase(s3://)', async (t) => {
     try {

--- a/test/to_tb.test.js
+++ b/test/to_tb.test.js
@@ -1,14 +1,11 @@
-'use strict';
-
 import test from 'tape';
-import path from 'path';
 import TileBase from '../tilebase.js';
 import { VectorTile } from '@mapbox/vector-tile';
 import Protobuf from 'pbf';
 
 test('TileBase#To_TB', async (t) => {
     try {
-        const tb = await TileBase.to_tb(path.resolve(__dirname, './fixtures/single.mbtiles'), '/tmp/test.tb');
+        const tb = await TileBase.to_tb(new URL('./fixtures/single.mbtiles', import.meta.url).pathname, '/tmp/test.tb');
 
         await tb.open();
 

--- a/test/to_tb.test.js
+++ b/test/to_tb.test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const test = require('tape');
-const path = require('path');
-const TileBase = require('../tilebase.js');
-const { VectorTile } = require('@mapbox/vector-tile');
-const Protobuf = require('pbf');
+import test from 'tape';
+import path from 'path';
+import TileBase from '../tilebase.js';
+import { VectorTile } from '@mapbox/vector-tile';
+import Protobuf from 'pbf';
 
 test('TileBase#To_TB', async (t) => {
     try {

--- a/test/to_tb_complicated.js
+++ b/test/to_tb_complicated.js
@@ -1,7 +1,4 @@
-'use strict';
-
 import test from 'tape';
-import path from 'path';
 import TileBase from '../tilebase.js';
 import { VectorTile } from '@mapbox/vector-tile';
 import MBTiles from '@mapbox/mbtiles';
@@ -9,7 +6,7 @@ import Protobuf from 'pbf';
 
 test('TileBase#To_TB (complicated)', async (t) => {
     try {
-        const tb = await TileBase.to_tb(path.resolve(__dirname, './fixtures/mesa.mbtiles'), '/tmp/mesa.tb');
+        const tb = await TileBase.to_tb(new URL('./fixtures/mesa.mbtiles', import.meta.url).pathname, '/tmp/mesa.tb');
         await tb.open();
 
         t.ok(tb instanceof TileBase, 'TileBase');
@@ -25,7 +22,7 @@ test('TileBase#To_TB (complicated)', async (t) => {
             }
         }, 'config: { obj }');
 
-        const mbt = await mbtiles(path.resolve(__dirname, './fixtures/mesa.mbtiles'));
+        const mbt = await mbtiles(new URL('./fixtures/mesa.mbtiles', import.meta.url).pathname);
 
         // Iterate through each tile and validate that it is a VT
         let tiles = 0;

--- a/test/to_tb_complicated.js
+++ b/test/to_tb_complicated.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const test = require('tape');
-const path = require('path');
-const TileBase = require('../tilebase.js');
-const { VectorTile } = require('@mapbox/vector-tile');
-const MBTiles = require('@mapbox/mbtiles');
-const Protobuf = require('pbf');
+import test from 'tape';
+import path from 'path';
+import TileBase from '../tilebase.js';
+import { VectorTile } from '@mapbox/vector-tile';
+import MBTiles from '@mapbox/mbtiles';
+import Protobuf from 'pbf';
 
 test('TileBase#To_TB (complicated)', async (t) => {
     try {

--- a/tilebase.js
+++ b/tilebase.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import fs from 'fs';
 import { promisify } from 'util';
 import MBTiles from '@mapbox/mbtiles';

--- a/tilebase.js
+++ b/tilebase.js
@@ -1,19 +1,19 @@
 'use strict';
 
-const fs = require('fs');
-const { promisify } = require('util');
-const MBTiles = require('@mapbox/mbtiles');
-const tc = require('@mapbox/tile-cover');
-const { point } = require('@turf/helpers');
-const bboxPolygon = require('@turf/bbox-polygon').default;
-const centroid = require('@turf/centroid').default;
-const TBError = require('./lib/error');
+import fs from 'fs';
+import { promisify } from 'util';
+import MBTiles from '@mapbox/mbtiles';
+import tc from '@mapbox/tile-cover';
+import { point } from '@turf/helpers';
+import bboxPolygon from '@turf/bbox-polygon';
+import centroid from '@turf/centroid';
+import TBError from './lib/error.js';
 
-const zlib = require('zlib');
-const TB = require('@mapbox/tilebelt');
+import zlib from 'zlib';
+import TB from '@mapbox/tilebelt';
 
-const Config = require('./lib/config');
-const interfaces = require('./lib/interfaces');
+import Config from './lib/config.js';
+import interfaces from './lib/interfaces.js';
 const gunzip = promisify(zlib.gunzip);
 
 /**
@@ -272,4 +272,4 @@ class TileBase {
     }
 }
 
-module.exports = TileBase;
+export default TileBase;


### PR DESCRIPTION
### Context

Node is strongly moving towards ES modules as the future. This migrates the entire library to be an ES module.

CommonJS modules should still be able to import this dynamically via:

```js
await import('tilebase');
```